### PR TITLE
fix bug with lstrip

### DIFF
--- a/odata/metadata.py
+++ b/odata/metadata.py
@@ -50,7 +50,7 @@ class MetaData(object):
 
     def _type_is_collection(self, typename):
         if typename.startswith('Collection('):
-            stripped = typename.lstrip('Collection(').rstrip(')')
+            stripped = typename[11:-1]
             return True, stripped
         else:
             return False, typename


### PR DESCRIPTION
Lstrip cuts more than needed if propertys name starts with capital C(or any lowercase character from 'ollection').
```
>>> property = 'Collection(Cats)'
>>> property.lstrip('Collection(')

'ats)'
```
From python docs:  str.lstrip([chars]) [...] The chars argument is not a prefix; rather, all combinations of its values are stripped.