### PR TITLE
Update setup.py to allow deployments to PyPI - #27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 build/
 doc/_build/
 venv/
+/AUTHORS
+/ChangeLog

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,47 @@
+[metadata]
+# 'odata' currently clashes with github.com/odatapy/odata which is 404  :-/
+name = odata
+version = 0.3
+license = MIT
+
+summary = A simple library for read/write access to OData services.
+long-description = file: README.md
+long-description-content-type = text/markdown
+author = Tuomas Mursu
+author-email = tuomas.mursu@kapsi.fi
+home-page = https://github.com/tuomur/python-odata
+
+require =
+    requests>=2.0
+    python-dateutil
+    enum-compat
+
+tests_require =
+    responses
+
+setup_require =
+    pbr>=1.8
+#    sphinx>=1.5
+
+classifier =
+    # 'Development Status :: 4 - Beta',  # Tuomas to make this call :-)
+    Environment :: Web Environment
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Topic :: Database
+    Topic :: Internet :: WWW/HTTP
+    Topic :: Internet :: WWW/HTTP :: Dynamic Content
+    Topic :: Software Development :: Libraries
+
+[files]
+packages =
+    odata
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,5 @@
 # -*- coding: utf-8 -*-
-
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 
-requires = [
-    'requests>=2.0',
-    'python-dateutil',
-]
-
-# support for enums from pypi when on older python
-if sys.version_info < (3, 4):
-    requires.append('enum34')
-
-tests_require = (
-    'responses',
-)
-
-setup(
-    name='odata',
-    version='0.3',
-    description='A simple library for read/write access to OData services.',
-    license='MIT',
-    author='Tuomas Mursu',
-    author_email='tuomas.mursu@kapsi.fi',
-    install_requires=requires,
-    tests_require=tests_require,
-    packages=find_packages(),
-)
+setup(pbr=True)


### PR DESCRIPTION
This possibly helps with pushing to PyPI. The "OData" name is taken (PyPI is case insensitive) so I've tested it using "python-odata" and using our Catalyst account to do a test upload onto [test-pypi](https://test.pypi.org/project/python-odata/). For some reason the Markdown README didn't translate, which the `long_description_content_type` setup parameter is supposed to handle.