### PR TITLE
Support EnumTypes that do not specify values

### DIFF
--- a/odata/metadata.py
+++ b/odata/metadata.py
@@ -399,13 +399,16 @@ class MetaData(object):
             'fully_qualified_name': '.'.join([schema_name, enum_name]),
             'members': []
         }
+        next_value = 0
         for enum_member in xmlq(enumtype_element, 'edm:Member'):
             member_name = enum_member.attrib['Name']
-            member_value = int(enum_member.attrib['Value'])
+            member_value = enum_member.attrib.get('Value', next_value)
+            member_value = int(member_value)
             enum['members'].append({
                 'name': member_name,
                 'value': member_value,
             })
+            next_value += 1
         return enum
 
     def parse_document(self, doc):

--- a/odata/tests/demo_metadata.xml
+++ b/odata/tests/demo_metadata.xml
@@ -15,6 +15,7 @@
                 <Property Name="Category" Type="Edm.String"/>
                 <Property Name="Price" Type="Edm.Decimal"/>
                 <Property Name="ColorSelection" Type="d.ColorSelection"/>
+                <Property Name="ShippingRestriction" Type="d.ShippingRestriction"/>
                 <Property Name="ExampleComputed" Type="Edm.Int32">
                     <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
                 </Property>
@@ -39,6 +40,12 @@
                 <Member Name="Red" Value="1"/>
                 <Member Name="Blue" Value="2"/>
                 <Member Name="Green" Value="3"/>
+            </EnumType>
+            <EnumType Name="ShippingRestriction">
+                <Member Name="Unrestricted" />
+                <Member Name="Fragile" />
+                <Member Name="Heavy" />
+                <Member Name="Oversize" />
             </EnumType>
         </Schema>
         <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="DemoService">

--- a/odata/tests/test_metadata.py
+++ b/odata/tests/test_metadata.py
@@ -45,6 +45,12 @@ class TestMetadataImport(TestCase):
 
         self.assertIn('DemoUnboundAction', Service.actions)
 
+        ColorSelection = Service.types['DemoService.Models.ColorSelection']
+        self.assertEqual(ColorSelection.Red.value, 1)
+        ShippingRestriction = Service.types[
+                'DemoService.Models.ShippingRestriction']
+        self.assertEqual(ShippingRestriction.Fragile.value, 1)
+
     def test_computed_value_in_insert(self):
         with responses.RequestsMock() as rsps:
             rsps.add(rsps.GET, 'http://demo.local/odata/$metadata/',


### PR DESCRIPTION
According to the [OData 4 Spec on Enumeration Types](http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part3-csdl/odata-v4.0-errata03-os-part3-csdl-complete.html#_Enumeration_Type) the Value attributes can be omitted. In this situation, the first one is considered to have a value of 0, the next is value 1, and so on.

I've added support for omitting the Value attribute, and updated the tests to include a demo EnumType that relies on this.

Tim