### PR TITLE
Fixed autofetch all pages when $top is set

### DIFF
--- a/odata/query.py
+++ b/odata/query.py
@@ -73,7 +73,7 @@ class Query(object):
                 for row in value:
                     yield self._create_model(row)
 
-                if '@odata.nextLink' in data:
+                if '@odata.nextLink' in data and not '$top' in options.keys(): #do not load next page on userpaging
                     url = urljoin(self.entity.__odata_url_base__, data['@odata.nextLink'])
                     options = {}  # we get all options in the nextLink url
                 else:


### PR DESCRIPTION
tuomur,
automatically following the "@odata.nextLink" breaks the sense of query().first()