### PR TITLE
Allow polymorph objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 build/
 doc/_build/
 venv/
+.vscode/
+debug.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.pyo
 *.egg-info
+*.code-workspace
 .idea
 dist
 build/

--- a/odata/query.py
+++ b/odata/query.py
@@ -73,7 +73,7 @@ class Query(object):
                 for row in value:
                     yield self._create_model(row)
 
-                if '@odata.nextLink' in data:
+                if '@odata.nextLink' in data and not '$top' in options.keys(): #do not load next page on userpaging
                     url = urljoin(self.entity.__odata_url_base__, data['@odata.nextLink'])
                     options = {}  # we get all options in the nextLink url
                 else:


### PR DESCRIPTION
Navigation property does not need to point to the real class of result objects. The object types can be mixed because of, navigation property points to a base class of them. --> DirectoryObjects --> Groups|Roles|Users|...
This fix resolves the object type based on response @odata.type and creates full featured object instances as they were queried directly