### PR TITLE
Delete slash in the end of URL

### DIFF
--- a/odata/metadata.py
+++ b/odata/metadata.py
@@ -41,7 +41,7 @@ class MetaData(object):
     _annotation_term_computed = 'Org.OData.Core.V1.Computed'
 
     def __init__(self, service):
-        self.url = service.url + '$metadata/'
+        self.url = service.url + '$metadata'
         self.connection = service.default_context.connection
         self.service = service
 


### PR DESCRIPTION
Any resources (https://data.nasa.gov/api/odata/v4/) returned an error:

```
{
    "error": {
        "code": null,
        "message": "The segment '$metadata' must be the last segment."
    }
}
```